### PR TITLE
Dfs v2

### DIFF
--- a/PowerView/powerview.ps1
+++ b/PowerView/powerview.ps1
@@ -6518,7 +6518,7 @@ function Invoke-StealthUserHunter {
         Return all user location results.
 
         .PARAMETER Source
-        The systems to use for session enumeration ("DC","File","All"). Defaults to "all"
+        The systems to use for session enumeration ("DFS","DC","File","All"). Defaults to "all"
 
         .PARAMETER SearchForest
         Search all domains in the forest for target users instead of just
@@ -6610,7 +6610,7 @@ function Invoke-StealthUserHunter {
         $ShowAll,
 
         [string]
-        [ValidateSet("DC","File","All")]
+        [ValidateSet("DFS","DC","File","All")]
         $Source ="All",
 
         [Switch]
@@ -6787,7 +6787,7 @@ function Invoke-StealthUserHunter {
     process {
 
         if ( (-not ($Hosts)) -or ($Hosts.length -eq 0)) {
-            
+
             [Array]$Hosts
 
             if($TargetDomains) {
@@ -6796,6 +6796,10 @@ function Invoke-StealthUserHunter {
                         Write-Verbose "[*] Querying domain $Domain for File Servers..."
                         $Hosts += Get-NetFileServer -Domain $Domain
 
+                    }
+                    elseif ($Source -eq "DFS"){
+                        Write-Verbose "[*] Querying domain $Domain for DFS Servers..."
+                        $Hosts += Get-NetDFSshare -Domain $Domain | % {$_.RemoteServerName}
                     }
                     elseif ($Source -eq "DC"){
                         Write-Verbose "[*] Querying domain $Domain for Domain Controllers..."

--- a/PowerView/powerview.ps1
+++ b/PowerView/powerview.ps1
@@ -3916,11 +3916,11 @@ function Get-NetFileServer {
 }
 
 
-function Get-DFSshare {
+function Get-DFSshareV1 {
     <#
         .SYNOPSIS
         Returns a list of all fault-tolerant distributed file
-        systems for a given domain.
+        systems (v1) for a given domain.
 
         .PARAMETER Domain
         The domain to query for user DFS shares.
@@ -3930,11 +3930,11 @@ function Get-DFSshare {
         Useful for OU queries.
 
         .EXAMPLE
-        > Get-DFSshares
+        > Get-DFSshareV1
         Returns all distributed file system shares for the current domain.
 
         .EXAMPLE
-        > Get-DFSshares -Domain test
+        > Get-DFSshareV1 -Domain test
         Returns all distributed file system shares for the 'test' domain.
     #>
 
@@ -3970,9 +3970,107 @@ function Get-DFSshare {
                 catch {}
             }
         }
-        # uniquify the set of DFS shares by the RemoteServerName
-        $DFSshares | Sort-Object -Property "RemoteServerName" -Unique
+        $DFSshares | Sort-Object -Property "RemoteServerName"
     }
+}
+
+function Get-DFSshareV2 {
+    <#
+        .SYNOPSIS
+        Returns a list of all fault-tolerant distributed file
+        systems (v2) for a given domain.
+
+        .PARAMETER Domain
+        The domain to query for user DFS shares.
+
+        .PARAMETER ADSpath
+        The LDAP source to search through, e.g. "LDAP://OU=secret,DC=testlab,DC=local"
+        Useful for OU queries.
+
+        .EXAMPLE
+        > Get-DFSshareV2
+        Returns all distributed file system shares for the current domain.
+
+        .EXAMPLE
+        > Get-DFSshareV2 -Domain test
+        Returns all distributed file system shares for the 'test' domain.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [string]
+        $Domain,
+
+        [string]
+        $ADSpath
+    )
+
+    $DFSsearcher = Get-DomainSearcher -Domain $Domain -ADSpath $ADSpath
+
+    if($DFSsearcher) {
+        $DFSshares = @()
+        $DFSsearcher.filter = "(&(objectClass=msDFS-Linkv2))"
+        $DFSSearcher.PropertiesToLoad.AddRange(('msdfs-linkpathv2','msDFS-TargetListv2'))
+        $DFSsearcher.PageSize = 200
+
+        $DFSSearcher.FindAll() | ? {$_} | ForEach-Object {
+            $properties = $_.Properties
+            $target_list = $properties.'msdfs-targetlistv2'[0]
+            $xml = [xml][System.Text.Encoding]::Unicode.GetString($target_list[2..($target_list.Length-1)])
+            $DFSshares += $xml.targets.ChildNodes | ForEach-Object {
+                try {
+                    $target = $_.InnerText
+                    if ( $target.Contains('\') ) {
+                        $dfs_root = $target.split("\")[3]
+                        $share_name = $properties.'msdfs-linkpathv2'[0]
+                        $out = new-object psobject
+                        $out | Add-Member Noteproperty 'Name' "$dfs_root$share_name"
+                        $out | Add-Member Noteproperty 'RemoteServerName' $target.split("\")[2]
+                        $out
+                    }
+                }
+                catch {}
+            }
+        }
+        $DFSshares | Sort-Object -Property "RemoteServerName"
+    }
+}
+
+function Get-DFSshare {
+    <#
+        .SYNOPSIS
+        Returns a list of all fault-tolerant distributed file
+        systems for a given domain.
+
+        .PARAMETER Domain
+        The domain to query for user DFS shares.
+
+        .PARAMETER ADSpath
+        The LDAP source to search through, e.g. "LDAP://OU=secret,DC=testlab,DC=local"
+        Useful for OU queries.
+
+        .EXAMPLE
+        > Get-DFSshare
+        Returns all distributed file system shares for the current domain.
+
+        .EXAMPLE
+        > Get-DFSshare -Domain test
+        Returns all distributed file system shares for the 'test' domain.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [string]
+        $Domain,
+
+        [string]
+        $ADSpath
+    )
+
+    $DFSshares = @()
+    $DFSshares += Get-DFSshareV1
+    $DFSshares += Get-DFSshareV2
+    $DFSshares | Sort-Object -Property "RemoteServerName"
 }
 
 ########################################################


### PR DESCRIPTION
Adds ability to query for v2 DFS shares (Win2k8 R2 upwards afaik). 

My previous domain was Win2k8 functional level. By upgrading to 2k8R2, then adding a DFS share (ticking the Win2008 option) I created a DFS share.

I think with V2 you create a share root by default, with no folders/links. If you then add a folder you should see links appear in LDAP which can then be queried. 

```
PS C:\Users\Administrator> Get-DFSsharev1

Name                                                               RemoteServerName                                                 
----                                                               ----------------                                                 
TestDFS                                                            WIN-2DE8F2QP867    
```


```
PS C:\Users\Administrator> Get-DFSsharev2

Name                                                               RemoteServerName                                                 
----                                                               ----------------                                                 
TestDFSRootv2/Home                                                 WIN-2DE8F2QP867    
```

```
PS C:\Users\Administrator> Get-DFSshare

Name                                                               RemoteServerName                                                 
----                                                               ----------------                                                 
TestDFS                                                            WIN-2DE8F2QP867                                                  
TestDFSRootv2/Home                                                 WIN-2DE8F2QP867  
```

The shares in v2 are in an UTF-16 XML ADSI hex array, but seems to have a couple of weird bytes at the start, which we strip. 