### PR TITLE
Groups by sid

### DIFF
--- a/PowerView/powerview.ps1
+++ b/PowerView/powerview.ps1
@@ -3714,6 +3714,7 @@ function Get-NetGroup {
 
             if ($SID) {
                 $GroupSearcher.filter = "(&(objectClass=group)(objectSID=$SID)$filter)"
+            }
             else {
                 $GroupSearcher.filter = "(&(objectClass=group)(name=$GroupName)$filter)"
             }

--- a/PowerView/powerview.ps1
+++ b/PowerView/powerview.ps1
@@ -3843,15 +3843,17 @@ function Get-NetGroupMember {
             if ($Recurse) {
                 # resolve the group to a distinguishedname
                 if ($GroupName) {
-                    $GroupDN = (Get-NetGroup -GroupName $GroupName -Domain $Domain -FullData).distinguishedname
+                    $Group = Get-NetGroup -GroupName $GroupName -Domain $Domain -FullData
                 }
                 elseif ($SID) {
-                    $GroupDN = (Get-NetGroup -SID $SID -Domain $Domain -FullData).distinguishedname
+                    $Group = Get-NetGroup -SID $SID -Domain $Domain -FullData
                 }
                 else {
                     $SID = (Get-DomainSID -Domain $Domain) + "-512"
-                    $GroupDN = (Get-NetGroup -SID $SID -Domain $Domain -FullData).distinguishedname
+                    $Group = Get-NetGroup -SID $SID -Domain $Domain -FullData
                 }
+                $GroupDN = $Group.distinguishedname
+                $GroupFoundName = $Group.name
 
                 if ($GroupDN) {
                     $GroupSearcher.filter = "(&(objectClass=user)(memberof:1.2.840.113556.1.4.1941:=$GroupDN)$filter)"
@@ -3861,7 +3863,7 @@ function Get-NetGroupMember {
                     $GroupFoundName = $GroupName
                 }
                 else {
-                    Write-Error "Unable to find GroupName"
+                    Write-Error "Unable to find Group"
                 }
             }
             else {


### PR DESCRIPTION
This changes Get-NetGroup to accept a SID, and Get-NetGroupMembers to default to the Domain Admins SID. Hopefully should be more language agnostic - but I have yet to test it in anger on foreign domains - not sure if all the other LDAP fields are the same? 

Also adds a Get-DomainSID command. 

n.b. I have fixed output to show the GroupName now for -recurse.

Ideally should also plug it into StealthUserHunter.

```
PS C:\Windows\System32\WindowsPowerShell\v1.0> Get-NetGroup -SID S-1-5-21-3469583980-2692176441-4150475799-512
Domain Admins
 

PS C:\Windows\System32\WindowsPowerShell\v1.0> Get-NetGroupMember -SID S-1-5-21-3469583980-2692176441-4150475799-512


GroupDomain  : test.lab
GroupName    : Domain Admins
MemberDomain : test.lab
MemberName   : parp
IsGroup      : True
MemberDN     : CN=parp,CN=Users,DC=test,DC=lab

GroupDomain  : test.lab
GroupName    : Domain Admins
MemberDomain : test.lab
MemberName   : Administrator
IsGroup      : False
MemberDN     : CN=Administrator,OU=Admins,DC=test,DC=lab




PS C:\Windows\System32\WindowsPowerShell\v1.0> Get-NetGroupMember -Recurse -SID S-1-5-21-3469583980-2692176441-4150475799-512


GroupDomain  : test.lab
GroupName    : 
MemberDomain : test.lab
MemberName   : Administrator
IsGroup      : False
MemberDN     : CN=Administrator,OU=Admins,DC=test,DC=lab

GroupDomain  : test.lab
GroupName    : 
MemberDomain : test.lab
MemberName   : test.user0001
IsGroup      : False
MemberDN     : CN=Test User (0001),CN=Users,DC=test,DC=lab




PS C:\Windows\System32\WindowsPowerShell\v1.0> Get-NetGroupMember -Recurse


GroupDomain  : test.lab
GroupName    : 
MemberDomain : test.lab
MemberName   : Administrator
IsGroup      : False
MemberDN     : CN=Administrator,OU=Admins,DC=test,DC=lab

GroupDomain  : test.lab
GroupName    : 
MemberDomain : test.lab
MemberName   : test.user0001
IsGroup      : False
MemberDN     : CN=Test User (0001),CN=Users,DC=test,DC=lab




PS C:\Windows\System32\WindowsPowerShell\v1.0> Get-NetGroupMember


GroupDomain  : test.lab
GroupName    : Domain Admins
MemberDomain : test.lab
MemberName   : parp
IsGroup      : True
MemberDN     : CN=parp,CN=Users,DC=test,DC=lab

GroupDomain  : test.lab
GroupName    : Domain Admins
MemberDomain : test.lab
MemberName   : Administrator
IsGroup      : False
MemberDN     : CN=Administrator,OU=Admins,DC=test,DC=lab




PS C:\Windows\System32\WindowsPowerShell\v1.0> 
```