### PR TITLE
Add service startname to output

### DIFF
--- a/PowerUp/PowerUp.ps1
+++ b/PowerUp/PowerUp.ps1
@@ -22,7 +22,7 @@ function Get-ModifiableFile {
 <#
     .SYNOPSIS
 
-        Hepler to return any modifiable file that's a part of a passed string.
+        Helper to return any modifiable file that's a part of a passed string.
         
     .EXAMPLE
 
@@ -117,6 +117,7 @@ function Get-ServiceUnquoted {
             $Out = New-Object PSObject 
             $Out | Add-Member Noteproperty 'ServiceName' $Service.name
             $Out | Add-Member Noteproperty 'Path' $Service.pathname
+            $Out | Add-Member Noteproperty 'StartName' $Service.startname
             $Out
         }
     }
@@ -143,12 +144,14 @@ function Get-ServiceFilePermission {
 
         $ServiceName = $_.name
         $ServicePath = $_.pathname
+        $ServiceStartName = $_.startname
 
         $ServicePath | Get-ModifiableFile | ForEach-Object {
             $Out = New-Object PSObject 
             $Out | Add-Member Noteproperty 'ServiceName' $ServiceName
             $Out | Add-Member Noteproperty 'Path' $ServicePath
             $Out | Add-Member Noteproperty 'ModifiableFile' $_
+            $Out | Add-Member Noteproperty 'StartName' $ServiceStartName
             $Out
         }
     }
@@ -185,6 +188,7 @@ function Get-ServicePermission {
                 $Out = New-Object PSObject 
                 $Out | Add-Member Noteproperty 'ServiceName' $Service.name
                 $Out | Add-Member Noteproperty 'Path' $Service.pathname
+                $Out | Add-Member Noteproperty 'StartName' $Service.startname
                 $Out
             }
         }


### PR DESCRIPTION
The user context which the service is running under was added to the
output of Get-ServiceUnquoted, Get-ServiceFilePermission, and
Get-ServicePermission. This is useful in situations where many services
were found to be vulnerable on the local machine however only a few are
running under the context of a different user (preferably NT
AUTHORITY\SYSTEM or a member of Domain Admins group).